### PR TITLE
Add DiT-based CIFAR-10 training script

### DIFF
--- a/dddm/__init__.py
+++ b/dddm/__init__.py
@@ -3,7 +3,7 @@ from .sampling import sample_dddm
 from .data import sample_gmm, GMM2D
 from .metrics import rbf_mmd2
 from .utils import save_scatter
-from .model import DDDMMLP
+from .model import DDDMMLP, DDDMDiT
 
 __all__ = [
     "TrainConfig",
@@ -14,4 +14,5 @@ __all__ = [
     "rbf_mmd2",
     "save_scatter",
     "DDDMMLP",
+    "DDDMDiT",
 ]

--- a/dddm/model.py
+++ b/dddm/model.py
@@ -3,6 +3,29 @@ import torch
 import torch.nn as nn
 
 
+class SinusoidalTimeEmbedding(nn.Module):
+    """Standard sinusoidal time embedding used in diffusion transformers."""
+
+    def __init__(self, dim: int, max_period: float = 10000.0) -> None:
+        super().__init__()
+        self.dim = dim
+        self.max_period = max_period
+
+    def forward(self, t: torch.Tensor) -> torch.Tensor:
+        if t.ndim != 1:
+            t = t.view(-1)
+        half = self.dim // 2
+        device = t.device
+        exponent = torch.arange(half, device=device, dtype=t.dtype)
+        exponent = -math.log(self.max_period) * exponent / max(half - 1, 1)
+        freqs = torch.exp(exponent)
+        args = t[:, None] * freqs[None]
+        emb = torch.cat([torch.sin(args), torch.cos(args)], dim=-1)
+        if self.dim % 2 == 1:
+            emb = torch.nn.functional.pad(emb, (0, 1))
+        return emb
+
+
 class TimeFeat(nn.Module):
     """Fourier time features."""
 
@@ -42,3 +65,180 @@ class DDDMMLP(nn.Module):
         tf = self.tfeat(t)
         h = torch.cat([xt, xi, tf], dim=-1)
         return self.net(h)
+
+
+class PatchEmbed(nn.Module):
+    """Embed images into a sequence of patch tokens."""
+
+    def __init__(
+        self,
+        img_size: int = 32,
+        patch_size: int = 4,
+        in_channels: int = 6,
+        embed_dim: int = 384,
+    ) -> None:
+        super().__init__()
+        if img_size % patch_size != 0:
+            raise ValueError("Image size must be divisible by patch size")
+        self.img_size = img_size
+        self.patch_size = patch_size
+        self.num_patches = (img_size // patch_size) ** 2
+        self.proj = nn.Conv2d(
+            in_channels,
+            embed_dim,
+            kernel_size=patch_size,
+            stride=patch_size,
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.proj(x)
+        x = x.flatten(2).transpose(1, 2)
+        return x
+
+
+class PatchUnembed(nn.Module):
+    """Map patch tokens back into image space."""
+
+    def __init__(
+        self,
+        img_size: int = 32,
+        patch_size: int = 4,
+        out_channels: int = 3,
+        embed_dim: int = 384,
+    ) -> None:
+        super().__init__()
+        self.img_size = img_size
+        self.patch_size = patch_size
+        self.out_channels = out_channels
+        self.embed_dim = embed_dim
+        self.num_patches_per_side = img_size // patch_size
+        self.proj = nn.Linear(embed_dim, out_channels * patch_size * patch_size)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        B, N, C = x.shape
+        if C != self.embed_dim:
+            raise ValueError("Unexpected embedding dimension")
+        h = self.num_patches_per_side
+        if N != h * h:
+            raise ValueError("Token count does not match image dimensions")
+        x = self.proj(x)
+        x = x.view(B, h, h, self.out_channels, self.patch_size, self.patch_size)
+        x = x.permute(0, 3, 1, 4, 2, 5).reshape(
+            B, self.out_channels, self.img_size, self.img_size
+        )
+        return x
+
+
+class MultiheadSelfAttention(nn.Module):
+    def __init__(self, dim: int, num_heads: int) -> None:
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("dim must be divisible by num_heads")
+        self.num_heads = num_heads
+        self.head_dim = dim // num_heads
+        self.scale = self.head_dim**-0.5
+        self.qkv = nn.Linear(dim, dim * 3)
+        self.proj = nn.Linear(dim, dim)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        B, N, C = x.shape
+        qkv = self.qkv(x).reshape(B, N, 3, self.num_heads, self.head_dim)
+        qkv = qkv.permute(2, 0, 3, 1, 4)
+        q, k, v = qkv[0], qkv[1], qkv[2]
+        attn = (q @ k.transpose(-2, -1)) * self.scale
+        attn = attn.softmax(dim=-1)
+        out = attn @ v
+        out = out.transpose(1, 2).reshape(B, N, C)
+        out = self.proj(out)
+        return out
+
+
+class FeedForward(nn.Module):
+    def __init__(self, dim: int, hidden_dim: int) -> None:
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(dim, hidden_dim),
+            nn.GELU(),
+            nn.Linear(hidden_dim, dim),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.net(x)
+
+
+class DiTBlock(nn.Module):
+    def __init__(self, dim: int, num_heads: int, mlp_ratio: float = 4.0) -> None:
+        super().__init__()
+        self.norm1 = nn.LayerNorm(dim)
+        self.attn = MultiheadSelfAttention(dim, num_heads)
+        self.norm2 = nn.LayerNorm(dim)
+        self.ff = FeedForward(dim, int(dim * mlp_ratio))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = x + self.attn(self.norm1(x))
+        x = x + self.ff(self.norm2(x))
+        return x
+
+
+class DDDMDiT(nn.Module):
+    """Distributional diffusion model with a DiT backbone for images."""
+
+    def __init__(
+        self,
+        img_size: int = 32,
+        patch_size: int = 4,
+        in_channels: int = 6,
+        out_channels: int = 3,
+        embed_dim: int = 384,
+        depth: int = 8,
+        num_heads: int = 6,
+        time_embed_dim: int = 256,
+        mlp_ratio: float = 4.0,
+    ) -> None:
+        super().__init__()
+        self.embed_dim = embed_dim
+        self.patch_embed = PatchEmbed(
+            img_size=img_size,
+            patch_size=patch_size,
+            in_channels=in_channels,
+            embed_dim=embed_dim,
+        )
+        self.pos_embed = nn.Parameter(
+            torch.zeros(1, self.patch_embed.num_patches, embed_dim)
+        )
+        self.time_embed = SinusoidalTimeEmbedding(time_embed_dim)
+        self.time_mlp = nn.Sequential(
+            nn.Linear(time_embed_dim, embed_dim),
+            nn.SiLU(),
+            nn.Linear(embed_dim, embed_dim),
+        )
+        self.blocks = nn.ModuleList(
+            [DiTBlock(embed_dim, num_heads, mlp_ratio) for _ in range(depth)]
+        )
+        self.norm = nn.LayerNorm(embed_dim)
+        self.unembed = PatchUnembed(
+            img_size=img_size,
+            patch_size=patch_size,
+            out_channels=out_channels,
+            embed_dim=embed_dim,
+        )
+        self.out_channels = out_channels
+
+        nn.init.trunc_normal_(self.pos_embed, std=0.02)
+
+    def forward(self, xt: torch.Tensor, t: torch.Tensor, xi: torch.Tensor) -> torch.Tensor:
+        if xt.shape != xi.shape:
+            raise ValueError("xt and xi must have the same shape")
+        if t.ndim != 1:
+            t = t.view(-1)
+        if xt.dim() != 4:
+            raise ValueError("Expecting image tensors with shape [B, C, H, W]")
+        x = torch.cat([xt, xi], dim=1)
+        h = self.patch_embed(x)
+        temb = self.time_mlp(self.time_embed(t))
+        h = h + temb[:, None, :] + self.pos_embed
+        for block in self.blocks:
+            h = block(h)
+        h = self.norm(h)
+        x0_hat = self.unembed(h)
+        return x0_hat

--- a/dddm/sampling.py
+++ b/dddm/sampling.py
@@ -1,26 +1,30 @@
+from typing import Sequence
+
 import torch
 
-from .model import DDDMMLP
 from .schedules import gaussian_bridge_mu_sigma
 
 
 @torch.no_grad()
 def sample_dddm(
-    model: DDDMMLP,
+    model: torch.nn.Module,
     n_samples: int = 4096,
     steps: int = 20,
     eps_churn: float = 1.0,
     device: str = "cpu",
+    data_shape: Sequence[int] | torch.Size | None = None,
 ) -> torch.Tensor:
     """Implements Algorithm 2 with coarse grid t_0=0<...<t_N=1."""
     model = model.to(device).eval()
     B = n_samples
     t_grid = torch.linspace(0.0, 1.0, steps + 1, device=device)
-    x = torch.randn(B, 2, device=device)
+    if data_shape is None:
+        data_shape = (2,)
+    x = torch.randn((B, *tuple(data_shape)), device=device)
     for k in reversed(range(steps)):
         s = t_grid[k]
         t = t_grid[k + 1]
-        xi = torch.randn(B, 2, device=device)
+        xi = torch.randn_like(x)
         xhat0 = model(x, t.repeat(B), xi)
         mu, std = gaussian_bridge_mu_sigma(s, t, xhat0, x, eps_churn=eps_churn)
         z = torch.randn_like(x)

--- a/dddm/schedules.py
+++ b/dddm/schedules.py
@@ -19,7 +19,10 @@ def forward_marginal_sample(x0: torch.Tensor, t: torch.Tensor, eps: torch.Tensor
     alpha_t, sigma_t = alpha_sigma(t)
     while eps.ndim < x0.ndim:
         eps = eps.unsqueeze(-1)
-    return alpha_t[..., None] * x0 + sigma_t[..., None] * eps
+    while alpha_t.ndim < x0.ndim:
+        alpha_t = alpha_t.unsqueeze(-1)
+        sigma_t = sigma_t.unsqueeze(-1)
+    return alpha_t * x0 + sigma_t * eps
 
 
 def gaussian_bridge_mu_sigma(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 torch
 matplotlib
+torchvision

--- a/train_cifar10_dit.py
+++ b/train_cifar10_dit.py
@@ -1,0 +1,184 @@
+"""Train a DiT-backed Distributional Diffusion Model on CIFAR-10."""
+
+import argparse
+import json
+import os
+
+import torch
+from torch.utils.data import DataLoader
+from torchvision import datasets, transforms, utils as tv_utils
+
+from dddm.losses import generalized_energy_terms, sigmoid_weight
+from dddm.model import DDDMDiT
+from dddm.schedules import forward_marginal_sample
+from dddm.sampling import sample_dddm
+
+
+def set_seed(seed: int) -> None:
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+
+
+def build_dataloader(data_dir: str, batch: int, workers: int) -> DataLoader:
+    transform = transforms.Compose(
+        [
+            transforms.ToTensor(),
+            transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5)),
+        ]
+    )
+    dataset = datasets.CIFAR10(
+        root=data_dir,
+        train=True,
+        download=True,
+        transform=transform,
+    )
+    return DataLoader(
+        dataset,
+        batch_size=batch,
+        shuffle=True,
+        num_workers=workers,
+        pin_memory=True,
+        drop_last=True,
+    )
+
+
+def save_checkpoint(model: torch.nn.Module, args: argparse.Namespace, outdir: str, name: str) -> None:
+    payload = {
+        "model": model.state_dict(),
+        "config": vars(args),
+    }
+    torch.save(payload, os.path.join(outdir, name))
+
+
+def train(args: argparse.Namespace) -> None:
+    device = torch.device(args.device)
+    set_seed(args.seed)
+    os.makedirs(args.out, exist_ok=True)
+
+    loader = build_dataloader(args.data_dir, args.batch, args.workers)
+    channels, image_size = 3, args.image_size
+
+    model = DDDMDiT(
+        img_size=image_size,
+        patch_size=args.patch_size,
+        in_channels=channels * 2,
+        out_channels=channels,
+        embed_dim=args.embed_dim,
+        depth=args.depth,
+        num_heads=args.heads,
+        time_embed_dim=args.time_embed,
+        mlp_ratio=args.mlp_ratio,
+    ).to(device)
+
+    opt = torch.optim.AdamW(
+        model.parameters(), lr=args.lr, weight_decay=args.weight_decay
+    )
+
+    global_step = 0
+    for epoch in range(1, args.epochs + 1):
+        model.train()
+        for x0, _ in loader:
+            x0 = x0.to(device)
+            B = x0.size(0)
+            t = torch.rand(B, device=device)
+            eps = torch.randn_like(x0)
+            xt = forward_marginal_sample(x0, t, eps)
+
+            xi = torch.randn(B, args.m, *x0.shape[1:], device=device)
+            xt_rep = xt.unsqueeze(1).expand(-1, args.m, -1, -1, -1)
+            xt_rep = xt_rep.reshape(-1, *x0.shape[1:])
+            xi_flat = xi.reshape(-1, *x0.shape[1:])
+            t_rep = t.repeat_interleave(args.m)
+
+            x0hat = model(xt_rep, t_rep, xi_flat)
+            x0hat = x0hat.view(B, args.m, *x0.shape[1:])
+
+            conf, inter = generalized_energy_terms(
+                x0hat.view(B, args.m, -1),
+                x0.view(B, -1),
+                beta=args.beta,
+                lam=args.lam,
+            )
+            w = sigmoid_weight(t, bias=args.w_bias).mean()
+            loss = w * (conf - (args.lam / (2.0 * (args.m - 1))) * inter)
+
+            opt.zero_grad(set_to_none=True)
+            loss.backward()
+            if args.grad_clip is not None and args.grad_clip > 0:
+                torch.nn.utils.clip_grad_norm_(model.parameters(), args.grad_clip)
+            opt.step()
+
+            global_step += 1
+            if global_step % args.log_every == 0:
+                print(
+                    f"[epoch {epoch:03d} step {global_step:06d}] loss={loss.item():.4f} "
+                    f"conf={conf.item():.4f} inter={inter.item():.4f} w~{w.item():.3f}"
+                )
+
+        if epoch % args.ckpt_every == 0 or epoch == args.epochs:
+            ckpt_name = f"model_epoch{epoch:03d}.pt"
+            save_checkpoint(model, args, args.out, ckpt_name)
+
+    save_checkpoint(model, args, args.out, "model_final.pt")
+
+    with open(os.path.join(args.out, "config.json"), "w") as f:
+        json.dump(vars(args), f, indent=2)
+
+    if args.sample_batch > 0:
+        model.eval()
+        with torch.no_grad():
+            samples = sample_dddm(
+                model,
+                n_samples=args.sample_batch,
+                steps=args.sample_steps,
+                eps_churn=args.eps_churn,
+                device=args.device,
+                data_shape=(channels, image_size, image_size),
+            )
+        samples = samples.clamp(-1.0, 1.0).cpu()
+        grid_rows = int(args.sample_batch**0.5)
+        if grid_rows * grid_rows < args.sample_batch:
+            grid_rows += 1
+        grid = tv_utils.make_grid((samples + 1.0) / 2.0, nrow=grid_rows)
+        tv_utils.save_image(grid, os.path.join(args.out, "samples.png"))
+        print(f"Saved samples and checkpoints to {args.out}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--data-dir", type=str, default="./data")
+    parser.add_argument("--out", type=str, default="./cifar10_dit_out")
+    parser.add_argument("--epochs", type=int, default=10)
+    parser.add_argument("--batch", type=int, default=128)
+    parser.add_argument("--lr", type=float, default=1e-4)
+    parser.add_argument("--weight-decay", type=float, default=0.01)
+    parser.add_argument("--beta", type=float, default=0.1)
+    parser.add_argument("--lam", type=float, default=1.0)
+    parser.add_argument("--m", type=int, default=8)
+    parser.add_argument("--w-bias", type=float, default=0.0, dest="w_bias")
+    parser.add_argument("--grad-clip", type=float, default=1.0)
+    parser.add_argument("--log-every", type=int, default=100)
+    parser.add_argument("--ckpt-every", type=int, default=1)
+    parser.add_argument("--device", type=str, default="cuda" if torch.cuda.is_available() else "cpu")
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--image-size", type=int, default=32)
+    parser.add_argument("--patch-size", type=int, default=4)
+    parser.add_argument("--embed-dim", type=int, default=384)
+    parser.add_argument("--depth", type=int, default=8)
+    parser.add_argument("--heads", type=int, default=6)
+    parser.add_argument("--time-embed", type=int, default=256)
+    parser.add_argument("--mlp-ratio", type=float, default=4.0)
+    parser.add_argument("--workers", type=int, default=4)
+    parser.add_argument("--sample-batch", type=int, default=64)
+    parser.add_argument("--sample-steps", type=int, default=20)
+    parser.add_argument("--eps-churn", type=float, default=1.0)
+    args = parser.parse_args()
+
+    if args.m < 2:
+        parser.error("m must be >= 2 for the generalized energy score")
+
+    train(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a DiT backbone implementation alongside the existing MLP denoiser
- generalize the diffusion sampling utilities to support high-dimensional data
- provide a CIFAR-10 training script that uses the new DiT model and saves checkpoints and samples
- include torchvision in the dependencies for CIFAR-10 data loading

## Testing
- python -m compileall dddm train_cifar10_dit.py

------
https://chatgpt.com/codex/tasks/task_e_68cbf6d7cd60832493135945b6016b3a