### PR TITLE
Add tqdm progress and wandb logging to training

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 torch
 matplotlib
 torchvision
+tqdm
+wandb

--- a/run_example.py
+++ b/run_example.py
@@ -27,6 +27,10 @@ def main() -> None:
     p.add_argument("--device", type=str, default="mps")
     p.add_argument("--seed", type=int, default=0)
     p.add_argument("--out", type=str, default="./out")
+    p.add_argument("--log-interval", type=int, default=200, dest="log_interval")
+    p.add_argument("--wandb", action="store_true", dest="use_wandb")
+    p.add_argument("--wandb-project", type=str, default="dddm")
+    p.add_argument("--wandb-name", type=str, default=None)
     args = p.parse_args()
 
     cfg = TrainConfig(
@@ -38,6 +42,10 @@ def main() -> None:
         batch=args.batch,
         device=args.device,
         seed=args.seed,
+        log_interval=args.log_interval,
+        use_wandb=args.use_wandb,
+        wandb_project=args.wandb_project,
+        wandb_run_name=args.wandb_name,
     )
     os.makedirs(args.out, exist_ok=True)
 


### PR DESCRIPTION
## Summary
- add tqdm-based progress bar and optional Weights & Biases logging to the 2D GMM training loop
- expose logging configuration in the TrainConfig dataclass and CLI example
- declare tqdm and wandb runtime dependencies

## Testing
- python -m compileall dddm run_example.py

------
https://chatgpt.com/codex/tasks/task_e_68cc592367ac8324bb168a8937a55f27